### PR TITLE
bitra: Reduce charging info size to avoid overlap with FOD icon

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ * Copyright (c) 2006, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+-->
+<resources>
+    <!-- The width/height of the unlock icon view on keyguard. -->
+    <dimen name="keyguard_indication_margin_bottom">102dp</dimen>
+
+    <!-- The text size for battery level -->
+    <dimen name="battery_level_text_size">05sp</dimen>
+</resources>


### PR DESCRIPTION
[@SathamHussainM edit]: Reduced charging info size further and moved it above FOD icon as our device FOD icon position is low so can't adapt it below the icon.

*original commit - https://github.com/ancient-devices/device_realme_RMX1901/commit/8cc31922a3918ceb230555f3c5d87a3e639f2a43

Co-authored-by: SathamHussainM <sathamhussain.m11@gmail.com>